### PR TITLE
Signal tracker level monitoring

### DIFF
--- a/Source/PitchEngine.swift
+++ b/Source/PitchEngine.swift
@@ -39,6 +39,10 @@ public class PitchEngine {
     }
   }
 
+  public var signalLevel:Float {
+    get { return signalTracker.averageLevel ?? 0.0 }
+  }
+
   // MARK: - Initialization
 
   public init(config: Config = Config(), delegate: PitchEngineDelegate? = nil) {

--- a/Source/PitchEngine.swift
+++ b/Source/PitchEngine.swift
@@ -3,8 +3,9 @@ import AVFoundation
 import Pitchy
 
 public protocol PitchEngineDelegate: class {
-  func pitchEngineDidRecievePitch(_ pitchEngine: PitchEngine, pitch: Pitch)
-  func pitchEngineDidRecieveError(_ pitchEngine: PitchEngine, error: Error)
+  func pitchEngineDidReceivePitch(_ pitchEngine: PitchEngine, pitch: Pitch)
+  func pitchEngineDidReceiveError(_ pitchEngine: PitchEngine, error: Error)
+  func pitchEngineWentBelowLevelThreshold(_ pitchEngine: PitchEngine)
 }
 
 open class PitchEngine {
@@ -87,7 +88,7 @@ open class PitchEngine {
         guard let weakSelf = self else { return }
 
         guard granted else {
-          weakSelf.delegate?.pitchEngineDidRecieveError(weakSelf,
+          weakSelf.delegate?.pitchEngineDidReceiveError(weakSelf,
             error: PitchEngineError.recordPermissionDenied as Error)
           return
         }
@@ -111,7 +112,7 @@ open class PitchEngine {
       try signalTracker.start()
       active = true
     } catch {
-      delegate?.pitchEngineDidRecieveError(self, error: error)
+      delegate?.pitchEngineDidReceiveError(self, error: error)
     }
   }
 }
@@ -133,13 +134,21 @@ extension PitchEngine: SignalTrackerDelegate {
           let pitch = try Pitch(frequency: Double(frequency))
 
           DispatchQueue.main.async {
-            weakSelf.delegate?.pitchEngineDidRecievePitch(weakSelf, pitch: pitch)
+            weakSelf.delegate?.pitchEngineDidReceivePitch(weakSelf, pitch: pitch)
           }
         } catch {
           DispatchQueue.main.async {
-            weakSelf.delegate?.pitchEngineDidRecieveError(weakSelf, error: error)
+            weakSelf.delegate?.pitchEngineDidReceiveError(weakSelf, error: error)
           }
         }
     }
   }
+
+  public func signalTrackerWentBelowLevelThreshold(_ signalTracker: SignalTracker) {
+    DispatchQueue.main.async {
+      self.delegate?.pitchEngineWentBelowLevelThreshold(self)
+    }
+
+  }
+
 }

--- a/Source/SignalTracking/SignalTracker.swift
+++ b/Source/SignalTracking/SignalTracker.swift
@@ -10,6 +10,8 @@ public protocol SignalTrackerDelegate: class {
 public protocol SignalTracker: class {
 
   var levelThreshold:Float? { get set }
+  var peakLevel:Float? { get }
+  var averageLevel:Float? { get }
   weak var delegate: SignalTrackerDelegate? { get set }
 
   func start() throws

--- a/Source/SignalTracking/SignalTracker.swift
+++ b/Source/SignalTracking/SignalTracker.swift
@@ -5,6 +5,8 @@ public protocol SignalTrackerDelegate: class {
   func signalTracker(_ signalTracker: SignalTracker,
     didReceiveBuffer buffer: AVAudioPCMBuffer,
     atTime time: AVAudioTime)
+
+  func signalTrackerWentBelowLevelThreshold(_ signalTracker:SignalTracker)
 }
 
 public protocol SignalTracker: class {

--- a/Source/SignalTracking/Units/InputSignalTracker.swift
+++ b/Source/SignalTracking/Units/InputSignalTracker.swift
@@ -61,6 +61,10 @@ open class InputSignalTracker: SignalTracker {
         DispatchQueue.main.async {
           self.delegate?.signalTracker(self, didReceiveBuffer: buffer, atTime: time)
         }
+      } else {
+        DispatchQueue.main.async {
+          self.delegate?.signalTrackerWentBelowLevelThreshold(self)
+        }
       }
     }
 

--- a/Source/SignalTracking/Units/InputSignalTracker.swift
+++ b/Source/SignalTracking/Units/InputSignalTracker.swift
@@ -16,15 +16,15 @@ public class InputSignalTracker: SignalTracker {
   private let session = AVAudioSession.sharedInstance()
   private let bus = 0
 
-  private var signalPeakLevel: Float {
+  public var peakLevel: Float? {
     get {
-      return audioChannel?.peakHoldLevel ?? 0.0
+      return audioChannel?.peakHoldLevel
     }
   }
 
-  private var signalAverageLevel: Float {
+  public var averageLevel: Float? {
     get {
-      return audioChannel?.averagePowerLevel ?? 0.0
+      return audioChannel?.averagePowerLevel
     }
   }
 
@@ -55,7 +55,7 @@ public class InputSignalTracker: SignalTracker {
 
       let levelThreshold = self.levelThreshold ?? -1000000.0
 
-      if self.signalAverageLevel > levelThreshold {
+      if self.averageLevel > levelThreshold {
         dispatch_async(dispatch_get_main_queue()) {
           self.delegate?.signalTracker(self, didReceiveBuffer: buffer, atTime: time)
         }

--- a/Source/SignalTracking/Units/InputSignalTracker.swift
+++ b/Source/SignalTracking/Units/InputSignalTracker.swift
@@ -53,9 +53,11 @@ open class InputSignalTracker: SignalTracker {
 
     inputNode.installTap(onBus: bus, bufferSize: bufferSize, format: format) { buffer, time in
 
+      guard let averageLevel = self.averageLevel else { return }
+
       let levelThreshold = self.levelThreshold ?? -1000000.0
 
-      if self.averageLevel > levelThreshold {
+      if averageLevel > levelThreshold {
         DispatchQueue.main.async {
           self.delegate?.signalTracker(self, didReceiveBuffer: buffer, atTime: time)
         }

--- a/Source/SignalTracking/Units/OutputSignalTracker.swift
+++ b/Source/SignalTracking/Units/OutputSignalTracker.swift
@@ -11,6 +11,15 @@ public class OutputSignalTracker: SignalTracker {
   private var audioPlayer: AVAudioPlayerNode!
   private let bus = 0
 
+  public var peakLevel: Float? {
+    get { return 0.0 }
+  }
+
+  public var averageLevel: Float? {
+    get { return 0.0 }
+  }
+
+
   // MARK: - Initialization
 
   public required init(audioURL: NSURL, bufferSize: AVAudioFrameCount = 2048, delegate: SignalTrackerDelegate? = nil) {


### PR DESCRIPTION
Allow access to level of current signal so it can be monitored - convenient if you need to display a level indicator or something similar. It can also be used to check if the signal went below the threshold, indicating a change in the note being played.
