### PR TITLE
Fix PitchEngine start on iOS10 : the installTap() block would never be called

### DIFF
--- a/Source/SignalTracking/Units/InputSignalTracker.swift
+++ b/Source/SignalTracking/Units/InputSignalTracker.swift
@@ -50,7 +50,7 @@ class InputSignalTracker: SignalTracker {
       throw InputSignalTrackerError.inputNodeMissing
     }
 
-    let format = inputNode.inputFormat(forBus: bus)
+    let format = inputNode.outputFormat(forBus: bus)
 
     inputNode.installTap(onBus: bus, bufferSize: bufferSize, format: format) { buffer, time in
       guard let averageLevel = self.averageLevel else { return }


### PR DESCRIPTION
This fixes a problem which occurs on iOS10, where on the first time a PitchEngine is instantiated and started, the installTap() block would never be called (and so no pitch recognition would happen). For some reason, this occurs only the first time a PitchEngine is created and run. Looking for some other examples of installTap, it seems one should pass the outputFormat and not the inputFormat as a parameter.

Signed-off-by: Guillaume Laurent <glaurent@telegraph-road.org>