### PR TITLE
Pluggable signal tracker

### DIFF
--- a/Beethoven.xcodeproj/project.pbxproj
+++ b/Beethoven.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		D5A49C751C343EC300427BF8 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5A49C731C343EC300427BF8 /* Quick.framework */; };
 		D5A49C761C343EC300427BF8 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5A49C741C343EC300427BF8 /* Nimble.framework */; };
 		D5A49CDE1C3458EA00427BF8 /* Pitchy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5A49CDD1C3458EA00427BF8 /* Pitchy.framework */; };
+		E0BF88FD1E85C31A00079F64 /* SimulatorSignalTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BF88FC1E85C31A00079F64 /* SimulatorSignalTracker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +94,7 @@
 		D5A49C731C343EC300427BF8 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		D5A49C741C343EC300427BF8 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		D5A49CDD1C3458EA00427BF8 /* Pitchy.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pitchy.framework; path = Carthage/Build/iOS/Pitchy.framework; sourceTree = "<group>"; };
+		E0BF88FC1E85C31A00079F64 /* SimulatorSignalTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimulatorSignalTracker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -290,6 +292,7 @@
 		D59CB14D1C345E0A00290B63 /* Units */ = {
 			isa = PBXGroup;
 			children = (
+				E0BF88FC1E85C31A00079F64 /* SimulatorSignalTracker.swift */,
 				D59CB14E1C345E0A00290B63 /* InputSignalTracker.swift */,
 				D59CB14F1C345E0A00290B63 /* OutputSignalTracker.swift */,
 			);
@@ -492,6 +495,7 @@
 				D5843EE41DBD2D290077F86E /* YINUtil.swift in Sources */,
 				D59CB1611C345E0A00290B63 /* MaxValueEstimator.swift in Sources */,
 				D59CB15F1C345E0A00290B63 /* HPSEstimator.swift in Sources */,
+				E0BF88FD1E85C31A00079F64 /* SimulatorSignalTracker.swift in Sources */,
 				D59CB16B1C345E0A00290B63 /* SimpleTransformer.swift in Sources */,
 				D5843EE21DBD2D110077F86E /* Array+Extensions.swift in Sources */,
 				D59CB1571C345E0A00290B63 /* Config.swift in Sources */,

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v5.1.0"
-github "Quick/Quick" "v0.10.0"
+github "Quick/Nimble" "v6.0.1"
+github "Quick/Quick" "v1.1.0"
 github "vadymmarkov/Pitchy" "2.0.1"

--- a/Source/SignalTracking/SignalTracker.swift
+++ b/Source/SignalTracking/SignalTracker.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-protocol SignalTrackerDelegate: class {
+public protocol SignalTrackerDelegate: class {
   func signalTracker(_ signalTracker: SignalTracker,
     didReceiveBuffer buffer: AVAudioPCMBuffer,
     atTime time: AVAudioTime)
@@ -8,7 +8,12 @@ protocol SignalTrackerDelegate: class {
   func signalTrackerWentBelowLevelThreshold(_ signalTracker: SignalTracker)
 }
 
-protocol SignalTracker: class {
+public enum SignalTrackerMode {
+  case record, playback
+}
+
+public protocol SignalTracker: class {
+  var mode: SignalTrackerMode { get }
   var levelThreshold: Float? { get set }
   var peakLevel: Float? { get }
   var averageLevel: Float? { get }

--- a/Source/SignalTracking/Units/InputSignalTracker.swift
+++ b/Source/SignalTracking/Units/InputSignalTracker.swift
@@ -28,6 +28,10 @@ class InputSignalTracker: SignalTracker {
     }
   }
 
+  var mode: SignalTrackerMode {
+    get { return .record }
+  }
+
   // MARK: - Initialization
 
   required init(bufferSize: AVAudioFrameCount = 2048,

--- a/Source/SignalTracking/Units/OutputSignalTracker.swift
+++ b/Source/SignalTracking/Units/OutputSignalTracker.swift
@@ -19,6 +19,10 @@ class OutputSignalTracker: SignalTracker {
   var averageLevel: Float? {
     get { return 0.0 }
   }
+  
+  var mode: SignalTrackerMode {
+    get { return .playback }
+  }
 
   // MARK: - Initialization
 

--- a/Source/SignalTracking/Units/SimulatorSignalTracker.swift
+++ b/Source/SignalTracking/Units/SimulatorSignalTracker.swift
@@ -1,0 +1,102 @@
+import AVFoundation
+
+/*
+ * A mock implemamtation of SignalTracker useful for unit testing and/or running in the simulator.
+ *
+ * It creates a series of PCM buffers filled with sine waves of given frequencies, 
+ * and passes the buffers to the delegate every delayMs milliseconds.
+ *
+ * Example:
+ *
+ * #if (arch(i386) || arch(x86_64)) && os(iOS)
+ *   // Simulator
+ *   let frequencies = try? [
+ *     391.995435981749,
+ *     391.995435981749,
+ *     415.304697579945,
+ *     Note(letter: Note.Letter.A, octave: 4).frequency,
+ *     466.163761518090,
+ *     466.163761518090,
+ *     Note(letter: Note.Letter.A, octave: 4).frequency,
+ *     415.304697579945,
+ *     391.995435981749
+ *   ]
+ *   let signalTracker = SimulatorSignalTracker(frequencies: frequencies, delayMs: 1000)
+ *   let pitchEngine = PitchEngine(config: config, signalTracker: signalTracker, delegate: delegate)
+ * #else
+ *   // Device
+ *   let pitchEngine = PitchEngine(config: config, delegate: delegate)
+ * #endif
+ *
+ */
+class SimulatorSignalTracker: SignalTracker {
+
+  var mode: SignalTrackerMode = .record
+
+  var levelThreshold: Float?
+
+  var peakLevel: Float?
+
+  var averageLevel: Float?
+
+  weak var delegate: SignalTrackerDelegate?
+
+  private var frequencies: [Double]?
+  private var delay: Int
+
+  private static let sampleRate = 8000.0
+  private static let sampleCount = 1024
+
+  public init(delegate: SignalTrackerDelegate? = nil, frequencies: [Double]? = nil, delayMs: Int = 0) {
+    self.delegate = delegate
+    self.frequencies = frequencies
+    self.delay = delayMs
+  }
+
+  func start() throws {
+    guard let frequencies = self.frequencies else { return }
+
+    let time = AVAudioTime(sampleTime: 0, atRate: SimulatorSignalTracker.sampleRate)
+
+    var i = 0
+
+    for frequency in frequencies {
+      let buffer = createPCMBuffer(frequency)
+      if i == 0 {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50), execute: {
+          self.delegate?.signalTracker(self, didReceiveBuffer: buffer, atTime: time)
+        })
+
+      } else {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delay * i), execute: {
+          self.delegate?.signalTracker(self, didReceiveBuffer: buffer, atTime: time)
+        })
+      }
+      i += 1
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delay * i), execute: {
+      self.delegate?.signalTrackerWentBelowLevelThreshold(self)
+    })
+  }
+
+  func stop() {
+  }
+
+  private func createPCMBuffer(_ frequency: Double) -> AVAudioPCMBuffer {
+    let format = AVAudioFormat(standardFormatWithSampleRate: SimulatorSignalTracker.sampleRate, channels: 1)
+    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(SimulatorSignalTracker.sampleCount))
+
+    if let channelData = buffer.floatChannelData {
+      let velocity = Float32(2.0 * M_PI * frequency / SimulatorSignalTracker.sampleRate)
+
+      for i in 0..<SimulatorSignalTracker.sampleCount {
+        let sample: Float32 = sin(velocity * Float32(i))
+        channelData[0][i] = sample
+      }
+
+      buffer.frameLength = buffer.frameCapacity
+    }
+
+    return buffer
+  }
+}

--- a/Source/SignalTracking/Units/SimulatorSignalTracker.swift
+++ b/Source/SignalTracking/Units/SimulatorSignalTracker.swift
@@ -29,17 +29,17 @@ import AVFoundation
  * #endif
  *
  */
-class SimulatorSignalTracker: SignalTracker {
+public class SimulatorSignalTracker: SignalTracker {
 
-  var mode: SignalTrackerMode = .record
+  public var mode: SignalTrackerMode = .record
 
-  var levelThreshold: Float?
+  public var levelThreshold: Float?
 
-  var peakLevel: Float?
+  public var peakLevel: Float?
 
-  var averageLevel: Float?
+  public var averageLevel: Float?
 
-  weak var delegate: SignalTrackerDelegate?
+  public weak var delegate: SignalTrackerDelegate?
 
   private var frequencies: [Double]?
   private var delay: Int
@@ -53,7 +53,7 @@ class SimulatorSignalTracker: SignalTracker {
     self.delay = delayMs
   }
 
-  func start() throws {
+  public func start() throws {
     guard let frequencies = self.frequencies else { return }
 
     let time = AVAudioTime(sampleTime: 0, atRate: SimulatorSignalTracker.sampleRate)
@@ -79,7 +79,7 @@ class SimulatorSignalTracker: SignalTracker {
     })
   }
 
-  func stop() {
+  public func stop() {
   }
 
   private func createPCMBuffer(_ frequency: Double) -> AVAudioPCMBuffer {


### PR DESCRIPTION
The rationale for this change is to make this awesome library more extendable and testable.

In current implementation there's now way to implement any kind of signal pre-processing or to make a pitch engine a part of a more complex audio graph.

Also, it's not that easy to write automated tests, because AVFoundation doesn't work in the simulator.

This simple change allows clients to provide their own implementation of SignalTracker protocol. But it doesn't change the overall behavior and semantics, and it's totally backwards compatible. It includes an implementation of a mock signal tracker, that can be used in various kinds of automated tests. 