### PR TITLE
Update .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
 disabled_rules:
   - type_name
+  - identifier_name
 
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level


### PR DESCRIPTION
After trying to build this project I got a build failure due to swiftlint raising an error for the lint rule `identifier_name` with version `0.30.1`.
Disabling this rule allows the build to succeed for now but maybe later fixing the source and enabling the rule again might be wise.