### PR TITLE
fix: sets `SWIFT_VERSION` to `4.0`

### DIFF
--- a/Beethoven.podspec
+++ b/Beethoven.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation', 'AVFoundation', 'Accelerate'
   s.dependency 'Pitchy', '~> 3.0'
 
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 end


### PR DESCRIPTION
I can't seem to build in Xcode 11 with Beethoven 4.0.2 installed via cocoapods.

It seems like `SWIFT_VERSION` was the issue.

Repo steps:
use `pod 'Beethoven'` 
do `pod update`
build via Xcode 11
-> Error: unsuppored `SWIFT_VERSION` 3...

No error when using the fork with the changes from this PR:
`pod 'Beethoven', :git => 'https://github.com/fetzig/Beethoven.git'`